### PR TITLE
Inspect the git repository to detect submodules

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -184,7 +184,10 @@ fn real_main(options: Options, config: &Config) -> CliResult {
                 // we are packaging
                 None
             } else if src_id.is_git() {
-                let url = git::git_to_yocto_git_url(src_id.url().as_str(), Some(pkg.name()));
+                // Just use the default download method for git repositories
+                // found in the source URIs, since cargo currently cannot
+                // initialize submodules for git dependencies anyway.
+                let url = git::git_to_yocto_git_url(src_id.url().as_str(), Some(pkg.name()), git::GitPrefix::default());
 
                 // save revision
                 src_uri_extras.push(format!("SRCREV_FORMAT .= \"_{}\"", pkg.name()));


### PR DESCRIPTION
If the project repo contains submodules, the yocto URL needs to specify
the gitsm fetcher instead of the git fetcher. Fixes #5.