### PR TITLE
Fixed doc link on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The license field supports any valid Cargo value and can be separated by `/` to 
 
 ## API
 
-API documentation is available at [docs.rs](https://docs.rs/cargo-bitbake/).
+API documentation is available at [docs.rs](https://docs.rs/crate/cargo-bitbake/0.3.10).
 
 ## Example output
 ```


### PR DESCRIPTION
The link on the readme to the docs was broken. This replaces it with the correct one.