### PR TITLE
Formatting fixes

### DIFF
--- a/src/bitbake.template
+++ b/src/bitbake.template
@@ -10,7 +10,7 @@ inherit cargo
 SRC_URI += "{project_src_uri}"
 SRCREV = "{project_src_rev}"
 S = "${{WORKDIR}}/git"
-CARGO_SRC_DIR="{project_rel_dir}"
+CARGO_SRC_DIR = "{project_rel_dir}"
 {git_srcpv}
 
 # please note if you have entries that do not begin with crate://
@@ -21,7 +21,7 @@ SRC_URI += " \
 {src_uri_extras}
 
 # FIXME: update generateme with the real MD5 of the license file
-LIC_FILES_CHKSUM=" \
+LIC_FILES_CHKSUM = " \
 {lic_files}"
 
 SUMMARY = "{summary}"

--- a/src/git.rs
+++ b/src/git.rs
@@ -68,6 +68,9 @@ pub fn git_to_yocto_git_url(url: &str, name: Option<&str>, prefix: GitPrefix) ->
         (_, _) => fixed_url.to_owned(),
     };
 
+    // by default bitbake only look for SHAs and refs on the master branch.
+    let yocto_url = format!("{};nobranch=1", yocto_url);
+
     if let Some(name) = name {
         format!("{};name={};destsuffix={}", yocto_url, name, name)
     } else {
@@ -145,7 +148,7 @@ mod test {
         let repo = "http://github.com/rust-lang/cargo.git";
         let url = git_to_yocto_git_url(repo, Some("cargo"), GitPrefix::Git);
         assert_eq!(url,
-                "git://github.com/rust-lang/cargo.git;protocol=http;name=cargo;destsuffix=cargo");
+                "git://github.com/rust-lang/cargo.git;protocol=http;nobranch=1;name=cargo;destsuffix=cargo");
     }
 
     #[test]
@@ -153,7 +156,7 @@ mod test {
         let repo = "https://github.com/rust-lang/cargo.git";
         let url = git_to_yocto_git_url(repo, Some("cargo"), GitPrefix::Git);
         assert_eq!(url,
-                "git://github.com/rust-lang/cargo.git;protocol=https;name=cargo;destsuffix=cargo");
+                "git://github.com/rust-lang/cargo.git;protocol=https;nobranch=1;name=cargo;destsuffix=cargo");
     }
 
     #[test]
@@ -161,28 +164,28 @@ mod test {
         let repo = "git@github.com:rust-lang/cargo.git";
         let url = git_to_yocto_git_url(repo, Some("cargo"), GitPrefix::Git);
         assert_eq!(url,
-                "git://git@github.com/rust-lang/cargo.git;protocol=ssh;name=cargo;destsuffix=cargo");
+                "git://git@github.com/rust-lang/cargo.git;protocol=ssh;nobranch=1;name=cargo;destsuffix=cargo");
     }
 
     #[test]
     fn remote_http_nosuffix() {
         let repo = "http://github.com/rust-lang/cargo.git";
         let url = git_to_yocto_git_url(repo, None, GitPrefix::Git);
-        assert_eq!(url, "git://github.com/rust-lang/cargo.git;protocol=http");
+        assert_eq!(url, "git://github.com/rust-lang/cargo.git;protocol=http;nobranch=1");
     }
 
     #[test]
     fn remote_https_nosuffix() {
         let repo = "https://github.com/rust-lang/cargo.git";
         let url = git_to_yocto_git_url(repo, None, GitPrefix::Git);
-        assert_eq!(url, "git://github.com/rust-lang/cargo.git;protocol=https");
+        assert_eq!(url, "git://github.com/rust-lang/cargo.git;protocol=https;nobranch=1");
     }
 
     #[test]
     fn remote_ssh_nosuffix() {
         let repo = "git@github.com:rust-lang/cargo.git";
         let url = git_to_yocto_git_url(repo, None, GitPrefix::Git);
-        assert_eq!(url, "git://git@github.com/rust-lang/cargo.git;protocol=ssh");
+        assert_eq!(url, "git://git@github.com/rust-lang/cargo.git;protocol=ssh;nobranch=1");
     }
 
     #[test]
@@ -190,7 +193,7 @@ mod test {
         let repo = "http://github.com/rust-lang/cargo.git";
         let url = git_to_yocto_git_url(repo, Some("cargo"), GitPrefix::Git);
         assert_eq!(url,
-                "git://github.com/rust-lang/cargo.git;protocol=http;name=cargo;destsuffix=cargo");
+                "git://github.com/rust-lang/cargo.git;protocol=http;nobranch=1;name=cargo;destsuffix=cargo");
     }
 
     #[test]
@@ -198,7 +201,7 @@ mod test {
         let repo = "https://github.com/rust-lang/cargo.git";
         let url = git_to_yocto_git_url(repo, Some("cargo"), GitPrefix::Git);
         assert_eq!(url,
-                "git://github.com/rust-lang/cargo.git;protocol=https;name=cargo;destsuffix=cargo");
+                "git://github.com/rust-lang/cargo.git;protocol=https;nobranch=1;name=cargo;destsuffix=cargo");
     }
 
     #[test]
@@ -206,7 +209,7 @@ mod test {
         let repo = "ssh://git@github.com/rust-lang/cargo.git";
         let url = git_to_yocto_git_url(repo, Some("cargo"), GitPrefix::Git);
         assert_eq!(url,
-                "git://git@github.com/rust-lang/cargo.git;protocol=ssh;name=cargo;destsuffix=cargo");
+                "git://git@github.com/rust-lang/cargo.git;protocol=ssh;nobranch=1;name=cargo;destsuffix=cargo");
     }
 
     #[test]
@@ -214,6 +217,6 @@ mod test {
         let repo = "git@github.com:rust-lang/cargo.git";
         let url = git_to_yocto_git_url(repo, Some("cargo"), GitPrefix::GitSubmodule);
         assert_eq!(url,
-                "gitsm://git@github.com/rust-lang/cargo.git;protocol=ssh;name=cargo;destsuffix=cargo");
+                "gitsm://git@github.com/rust-lang/cargo.git;protocol=ssh;nobranch=1;name=cargo;destsuffix=cargo");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,7 +178,7 @@ fn real_main(options: Options, config: &mut Config) -> CliResult {
                 None
             } else if src_id.is_registry() {
                 // this package appears in a crate registry
-                Some(format!("crate://{}/{}/{} \\\n",
+                Some(format!("    crate://{}/{}/{} \\\n",
                              CRATES_IO_URL,
                              pkg.name(),
                              pkg.version()))
@@ -212,9 +212,9 @@ fn real_main(options: Options, config: &mut Config) -> CliResult {
                 src_uri_extras
                     .push(format!("EXTRA_OECARGO_PATHS += \"${{WORKDIR}}/{}\"", pkg.name()));
 
-                Some(url)
+                Some(format!("    {} \\\n", url))
             } else {
-                Some(format!("{} \\\n", src_id.url().to_string()))
+                Some(format!("    {} \\\n", src_id.url().to_string()))
             }
         })
         .collect::<Vec<String>>();
@@ -271,8 +271,11 @@ fn real_main(options: Options, config: &mut Config) -> CliResult {
 
     // license files for the package
     let mut lic_files = vec![];
-    for lic in license.split('/') {
-        lic_files.push(license::file(crate_root, &rel_dir, lic));
+    let licenses: Vec<&str> = license.split('/').collect();
+    let single_license = licenses.len() == 1;
+    for lic in licenses {
+        lic_files.push(format!("    {}", license::file(crate_root, &rel_dir, lic,
+                                                       single_license)));
     }
 
     // license data in Yocto fmt


### PR DESCRIPTION
I've put together some formatting fixes, git crates had no newline and indention before lists.

Also, if Cargo.toml only specify one license, it will look for a file called LICENSE and generate a SHA for that.

Add nobranch=1 to git crates so that they will use them even if the commit is not on master.

I've tested this on librespot and it seems to generate a working recipe even though the actual application do not build.