### PR TITLE
Repository moved from `cardoe` to `meta-rust` org

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,24 +2,24 @@
 authors = ["Doug Goldstein <cardoe@cardoe.com>"]
 categories = ["command-line-utilities"]
 description = "Generates a BitBake recipe for a package utilizing meta-rust's classes."
-documentation = "https://github.com/cardoe/cargo-bitbake"
-homepage = "https://github.com/cardoe/cargo-bitbake"
+documentation = "https://github.com/meta-rust/cargo-bitbake"
+homepage = "https://github.com/meta-rust/cargo-bitbake"
 keywords = ["cargo-subcommand", "bitbake", "yocto", "recipe"]
 license = "MIT/Apache-2.0"
 edition = "2018"
 name = "cargo-bitbake"
 readme = "README.md"
-repository = "https://github.com/cardoe/cargo-bitbake"
+repository = "https://github.com/meta-rust/cargo-bitbake"
 version = "0.3.16-alpha.0"
 rust-version = "1.60"
 
 [badges]
-is-it-maintained-issue-resolution = { repository = "cardoe/cargo-bitbake" }
-is-it-maintained-open-issues = { repository = "cardoe/cargo-bitbake" }
+is-it-maintained-issue-resolution = { repository = "meta-rust/cargo-bitbake" }
+is-it-maintained-open-issues = { repository = "meta-rust/cargo-bitbake" }
 maintenance = { status = "passively-maintained" }
 
 [badges.travis-ci]
-repository = "cardoe/cargo-bitbake"
+repository = "meta-rust/cargo-bitbake"
 
 [dependencies]
 anyhow = "^1.0"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cargo-bitbake
 
-[![Build Status](https://travis-ci.org/cardoe/cargo-bitbake.svg?branch=master)](https://travis-ci.org/cardoe/cargo-bitbake) [![Latest Version](https://img.shields.io/crates/v/cargo-bitbake.svg)](https://crates.io/crates/cargo-bitbake)
+[![Build Status](https://travis-ci.org/meta-rust/cargo-bitbake.svg?branch=master)](https://travis-ci.org/meta-rust/cargo-bitbake) [![Latest Version](https://img.shields.io/crates/v/cargo-bitbake.svg)](https://crates.io/crates/cargo-bitbake)
 
 `cargo bitbake` is a Cargo subcommand that generates a
 [BitBake](https://en.wikipedia.org/wiki/BitBake) recipe that uses
@@ -123,6 +123,6 @@ LIC_FILES_CHKSUM=" \
 "
 
 SUMMARY = "Generates a BitBake recipe for a package utilizing meta-rust's classes."
-HOMEPAGE = "https://github.com/cardoe/cargo-bitbake"
+HOMEPAGE = "https://github.com/meta-rust/cargo-bitbake"
 LICENSE = "MIT | Apache-2.0"
 ```

--- a/src/git.rs
+++ b/src/git.rs
@@ -19,7 +19,7 @@ use std::fmt::{self, Display};
 
 /// basic pattern to match ssh style remote URLs
 /// so that they can be fixed up
-/// git@github.com:cardoe/cargo-bitbake.git should match
+/// git@github.com:meta-rust/cargo-bitbake.git should match
 const SSH_STYLE_REMOTE_STR: &str = r".*@.*:.*";
 
 lazy_static! {
@@ -53,7 +53,7 @@ impl Display for GitPrefix {
 
 /// converts a GIT URL to a Yocto GIT URL
 pub fn git_to_yocto_git_url(url: &str, name: Option<&str>, prefix: GitPrefix) -> String {
-    // check if its a git@github.com:cardoe/cargo-bitbake.git style URL
+    // check if its a git@github.com:meta-rust/cargo-bitbake.git style URL
     // and fix it up if it is
     let fixed_url = if SSH_STYLE_REMOTE.is_match(url) {
         format!("ssh://{}", url.replace(":", "/"))


### PR DESCRIPTION
Just tidying things up by updating references to https://github.com/cardoe/cargo-bitbake to instead point to https://github.com/meta-rust/cargo-bitbake where this repository now resides under the `meta-rust` organization.

I hope this should also fix the broken build status indicator, as Travis CI seems to recognize the latter but not the former name.